### PR TITLE
Add terminal quick actions, ambient sound, and animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,28 @@ Launch the terminal below and explore:
 
 ---
 
+## 🌐 Deploy It for Anyone (Vercel Quickstart)
+
+Want to share this terminal experience broadly? Vercel’s static hosting makes
+it a one-command deploy:
+
+1. [Install the Vercel CLI](https://vercel.com/docs/cli) if you haven’t
+   already: `npm i -g vercel`.
+2. Authenticate: `vercel login`.
+3. From the project root, run `vercel` and accept the defaults to create the
+   project.
+4. Deploy updates any time with `vercel --prod`.
+
+The app is a static site (HTML/CSS/JS), so Vercel serves it instantly with no
+extra configuration. You can also drop the folder into Netlify, GitHub Pages,
+or any static host.
+
+---
+
 **Ready to code the future? So am I!**
 
 ---
 
-*No personal or contact data included. For demo and application purposes 
+*No personal or contact data included. For demo and application purposes
 only.*
 ```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex PM Terminal | Tanya Batsenko</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="viewport">
+      <header class="hero">
+        <h1>$ whois tanya-batsenko</h1>
+        <p>
+          Welcome to an open web terminal that anyone can explore. Type
+          <span class="command">help</span> to discover why I'd make Codex the
+          most beloved AI coding partner on the planet.
+        </p>
+      </header>
+      <section class="terminal" aria-live="polite">
+        <div id="output" class="terminal__output" role="log">
+          <div class="line">Codex://pm> boot sequence initialized...</div>
+          <div class="line">Loading developer empathy modules... ✅</div>
+          <div class="line">Loading 0-to-1 product playbooks... ✅</div>
+          <div class="line">Connecting to OpenAI Codex vision... ✅</div>
+          <div class="line">Type <span class="command">help</span> to begin.</div>
+        </div>
+        <div class="terminal__actions" role="group" aria-label="Suggested commands">
+          <button type="button" class="chip" data-command="help">help</button>
+          <button type="button" class="chip" data-command="show experience">show experience</button>
+          <button type="button" class="chip" data-command="show motivation">show motivation</button>
+          <button type="button" class="chip" data-command="play challenge">play challenge</button>
+          <button
+            type="button"
+            class="chip chip--ghost"
+            id="toggle-sound"
+            aria-pressed="false"
+            data-state="off"
+          >
+            🔈 Enable ambience
+          </button>
+        </div>
+        <form class="terminal__input" id="terminal-form">
+          <label class="sr-only" for="command">Enter a command</label>
+          <span class="prompt">Codex://pm&gt;</span>
+          <input
+            id="command"
+            name="command"
+            type="text"
+            autocomplete="off"
+            spellcheck="false"
+            aria-label="Command line"
+          />
+        </form>
+      </section>
+      <footer class="footer">
+        <p>
+          Built by Tanya (Tetiana) Batsenko &mdash; AI Product Manager who blends
+          research breakthroughs into tools developers love.
+        </p>
+      </footer>
+    </main>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,338 @@
+const outputEl = document.getElementById("output");
+const form = document.getElementById("terminal-form");
+const commandInput = document.getElementById("command");
+const toggleSoundBtn = document.getElementById("toggle-sound");
+const suggestionButtons = document.querySelectorAll(".chip[data-command]");
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let audioCtx;
+let ambienceCreated = false;
+let autoSoundTriggered = false;
+
+const createAmbience = () => {
+  if (ambienceCreated) return;
+  const AudioContextConstructor =
+    window.AudioContext || window.webkitAudioContext;
+  if (!AudioContextConstructor) {
+    console.warn("Web Audio API is not supported in this browser.");
+    return;
+  }
+
+  audioCtx = new AudioContextConstructor();
+
+  const baseOsc = audioCtx.createOscillator();
+  baseOsc.type = "sine";
+  baseOsc.frequency.value = 140;
+
+  const shimmerOsc = audioCtx.createOscillator();
+  shimmerOsc.type = "triangle";
+  shimmerOsc.frequency.value = 420;
+
+  const baseGain = audioCtx.createGain();
+  baseGain.gain.value = 0.08;
+
+  const shimmerGain = audioCtx.createGain();
+  shimmerGain.gain.value = 0.03;
+
+  const lfo = audioCtx.createOscillator();
+  lfo.type = "sine";
+  lfo.frequency.value = 0.08;
+
+  const lfoGain = audioCtx.createGain();
+  lfoGain.gain.value = 0.02;
+
+  const shimmerLfo = audioCtx.createOscillator();
+  shimmerLfo.type = "sine";
+  shimmerLfo.frequency.value = 0.05;
+
+  const shimmerLfoGain = audioCtx.createGain();
+  shimmerLfoGain.gain.value = 40;
+
+  lfo.connect(lfoGain);
+  lfoGain.connect(baseGain.gain);
+
+  shimmerLfo.connect(shimmerLfoGain);
+  shimmerLfoGain.connect(shimmerOsc.frequency);
+
+  baseOsc.connect(baseGain);
+  shimmerOsc.connect(shimmerGain);
+  shimmerGain.connect(baseGain);
+  baseGain.connect(audioCtx.destination);
+
+  baseOsc.start();
+  shimmerOsc.start();
+  lfo.start();
+  shimmerLfo.start();
+
+  ambienceCreated = true;
+};
+
+const updateSoundButton = (state) => {
+  if (!toggleSoundBtn) return;
+  toggleSoundBtn.dataset.state = state;
+  toggleSoundBtn.setAttribute("aria-pressed", state === "on" ? "true" : "false");
+  toggleSoundBtn.textContent =
+    state === "on" ? "🔊 Mute ambience" : "🔈 Enable ambience";
+};
+
+const startAmbient = async () => {
+  try {
+    if (!ambienceCreated) {
+      createAmbience();
+    }
+    if (!audioCtx) {
+      updateSoundButton("off");
+      return false;
+    }
+    await audioCtx.resume();
+    updateSoundButton("on");
+    return true;
+  } catch (error) {
+    console.warn("Unable to start ambience", error);
+    return false;
+  }
+};
+
+const stopAmbient = async () => {
+  if (!audioCtx) return;
+  if (audioCtx.state === "running") {
+    await audioCtx.suspend();
+  }
+  updateSoundButton("off");
+};
+
+const typeLine = async (text, options = {}) => {
+  const { className = "line", delayMs = 0 } = options;
+  if (delayMs) await delay(delayMs);
+  const line = document.createElement("div");
+  line.className = className;
+  line.innerHTML = text;
+  outputEl.appendChild(line);
+  outputEl.scrollTop = outputEl.scrollHeight;
+};
+
+const scenarios = [
+  {
+    intro:
+      "🚀 PM Challenge: Codex users are waiting for multi-file editing suggestions. How do you prioritize?",
+    options: [
+      "1. Ship immediately with lightweight heuristics.",
+      "2. Run developer shadowing, prototype, and test signal quality before scaling.",
+      "3. Pause: invest in infra first, then revisit in six months.",
+    ],
+    answer:
+      "I'd choose option 2: shadow power users, pair with research on signal quality, and prototype in the agent harness. This balances speed with trust—Codex must accelerate developers, not slow them down.",
+  },
+  {
+    intro:
+      "🧠 PM Challenge: Researchers just unlocked a brand-new planning capability. What's the move?",
+    options: [
+      "1. Publish a blog post and wait for community feedback.",
+      "2. Embed the capability in an internal dogfood workflow with telemetry.",
+      "3. Turn it into an API endpoint with minimal guardrails.",
+    ],
+    answer:
+      "Option 2: partner with internal teams to dogfood, gather telemetry, and define guardrails. Then use those learnings to craft a developer-first launch with clear value moments.",
+  },
+  {
+    intro:
+      "⚙️ PM Challenge: Infra costs are spiking as usage doubles. What now?",
+    options: [
+      "1. Throttle access for new teams.",
+      "2. Pair with infra to optimize prompts, caching, and evaluation loops.",
+      "3. Freeze feature work entirely.",
+    ],
+    answer:
+      "I'd go with option 2: collaborate with infra to optimize prompts, caching, and evaluation loops—just like I did at Red Bull when we cut AI costs while scaling to 70K users.",
+  },
+];
+
+let activeScenario = null;
+
+const commandHandlers = {
+  help: () => {
+    return [
+      "Available commands:",
+      "- <span class=\"command\">show experience</span> &mdash; Explore 0-to-1 wins and product outcomes.",
+      "- <span class=\"command\">show skills</span> &mdash; Peek at my technical toolkit.",
+      "- <span class=\"command\">show motivation</span> &mdash; Hear why Codex is my moonshot.",
+      "- <span class=\"command\">show role</span> &mdash; Highlight how I map to the Codex PM mandate.",
+      "- <span class=\"command\">play challenge</span> &mdash; Try an interactive PM scenario.",
+      "- <span class=\"command\">clear</span> &mdash; Clear the terminal.",
+    ];
+  },
+  "show experience": () => {
+    return [
+      "<strong>Red Bull Media House | AI Product Manager</strong>",
+      "• Shipped the company's first global AI product: 0 → 70K users across 40 countries, delivering 20x YoY growth.",
+      "• Designed product vision and roadmap from 20+ interviews and 100+ data points, hitting 30% view → activation conversion.",
+      "• Built fraud-mitigation & data integrity systems with legal/security, reducing invalid submissions by 21%.",
+      "• Accelerated iteration 4× via a generative AI evaluation framework, partnering with Microsoft, AWS, and Suno researchers.",
+      "<strong>Google | Software Engineer, Google AdSense</strong>",
+      "• Launched a self-service A/B testing API that lifted ARR by $12M in 6 months for automatic search ads.",
+      "• Engineered SQL-based monitoring for systems powering 1M+ publishers and uncovered a critical revenue bug in week three.",
+      "• Collaborated with design & legal to streamline experimentation workflows, reducing feature churn by 3%.",
+      "<strong>Google | SWE Internships</strong>",
+      "• Built an AutoAds sampling algorithm still in production; led developer research for internal tooling used by 30K+ engineers.",
+    ];
+  },
+  "show skills": () => {
+    return [
+      "Technical toolkit unlocked:",
+      "• Languages & Data: Python, SQL, large-scale data pipelines, experimentation design, AI prototyping.",
+      "• AI & Infra: LLM evaluation, prompt engineering, GenAI quality measurement, cost optimization across AWS/GCP/Azure.",
+      "• Product Superpowers: 0→1 strategy, developer workflow empathy, hypothesis-driven discovery, cross-functional leadership.",
+      "• Communication: Exec-ready storytelling, stakeholder management, vision setting that rallies researchers, designers & engineers.",
+    ];
+  },
+  "show motivation": () => {
+    return [
+      "My Codex north star:",
+      "I want to help OpenAI make Codex the best AI collaborator engineers have ever worked with—one that truly accelerates development, not just assists it.",
+      "I'll bridge research and product so breakthroughs become daily tools developers rely on.",
+      "Expect deep empathy for developer workflows, relentless experimentation, and a drive to shape how AGI becomes a creative, reliable coding partner.",
+    ];
+  },
+  "show role": () => {
+    return [
+      "Mapping to the Codex PM mission:",
+      "• <strong>Shape product strategy in 0–1 spaces:</strong> Led ambiguous greenfield launches at Red Bull and Google, aligning teams around a shared vision.",
+      "• <strong>Translate breakthroughs into developer magic:</strong> Partnered with research orgs (Microsoft, AWS, Suno) to ship delightful AI audio tools.",
+      "• <strong>Deep developer empathy:</strong> Built experimentation platforms and developer-facing APIs that improved workflows for 1M+ AdSense publishers.",
+      "• <strong>Execute with technical rigor:</strong> Recently shipped code, managed infra costs, and set up AI quality evaluation loops.",
+      "• <strong>Entrepreneurial and adaptable:</strong> From startup-speed iterations to global rollouts, I thrive where ambiguity meets opportunity.",
+    ];
+  },
+  clear: () => {
+    outputEl.innerHTML = "";
+    return [];
+  },
+  "play challenge": () => {
+    activeScenario = scenarios[Math.floor(Math.random() * scenarios.length)];
+    const lines = [activeScenario.intro, "Choose wisely:"].concat(activeScenario.options);
+    lines.push("Respond with <span class=\"command\">answer 1</span>, <span class=\"command\">answer 2</span>, or <span class=\"command\">answer 3</span>.");
+    return lines;
+  },
+};
+
+const answerHandler = (choice) => {
+  if (!activeScenario) {
+    return [
+      "No active challenge. Start one with <span class=\"command\">play challenge</span>.",
+    ];
+  }
+  const selected = Number(choice) - 1;
+  const response = activeScenario.options[selected]
+    ? activeScenario.answer
+    : "That option isn't in the backlog yet. Try 1, 2, or 3.";
+  const lines = [];
+  if (activeScenario.options[selected]) {
+    lines.push(`You chose option ${choice}.`);
+    lines.push(activeScenario.answer);
+    lines.push(
+      "Curious how I'd iterate next? Ask with <span class=\"command\">show experience</span> or <span class=\"command\">show motivation</span>."
+    );
+    activeScenario = null;
+  } else {
+    lines.push(response);
+  }
+  return lines;
+};
+
+const history = [];
+let historyIndex = 0;
+
+const processCommand = async (rawInput, options = {}) => {
+  const { storeHistory = true, echo = true } = options;
+  const input = rawInput.trim();
+  if (!input) return;
+
+  if (!autoSoundTriggered) {
+    const started = await startAmbient();
+    if (started) {
+      autoSoundTriggered = true;
+    }
+  }
+
+  if (storeHistory) {
+    history.push(input);
+  }
+  historyIndex = history.length;
+
+  if (echo) {
+    await typeLine(`<span class="prompt">Codex://pm&gt;</span> ${input}`);
+  }
+
+  const lower = input.toLowerCase();
+
+  if (lower.startsWith("answer")) {
+    const option = lower.split(" ")[1];
+    const lines = answerHandler(option);
+    for (const line of lines) {
+      await typeLine(line, { delayMs: 80 });
+    }
+    return;
+  }
+
+  const handler = commandHandlers[lower];
+  if (handler) {
+    const lines = handler();
+    for (const line of lines) {
+      await typeLine(line, { delayMs: 80 });
+    }
+  } else {
+    await typeLine(
+      "Command not recognized. Try <span class=\"command\">help</span> to see what's available.",
+      { delayMs: 80 }
+    );
+  }
+};
+
+commandInput.addEventListener("keydown", (event) => {
+  if (!history.length) return;
+  if (event.key === "ArrowUp") {
+    event.preventDefault();
+    historyIndex = Math.max(0, historyIndex - 1);
+    commandInput.value = history[historyIndex];
+  }
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    historyIndex = Math.min(history.length, historyIndex + 1);
+    commandInput.value = history[historyIndex] ?? "";
+  }
+});
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const rawInput = commandInput.value;
+  commandInput.value = "";
+  await processCommand(rawInput);
+});
+
+suggestionButtons.forEach((button) => {
+  button.addEventListener("click", async () => {
+    const command = button.dataset.command;
+    if (!command) return;
+    await processCommand(command, { storeHistory: false });
+    commandInput.focus();
+  });
+});
+
+if (toggleSoundBtn) {
+  toggleSoundBtn.addEventListener("click", async () => {
+    const state = toggleSoundBtn.dataset.state;
+    if (state === "on") {
+      await stopAmbient();
+    } else {
+      const started = await startAmbient();
+      if (started) {
+        autoSoundTriggered = true;
+      }
+    }
+    commandInput.focus();
+  });
+}
+
+typeLine("Need a tour? Type <span class=\"command\">help</span>.", { delayMs: 400 });
+commandInput.focus();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,276 @@
+:root {
+  --bg: #05060a;
+  --panel: rgba(8, 12, 20, 0.9);
+  --text: #d1f7ff;
+  --accent: #7efcf6;
+  --muted: #66808a;
+  --prompt: #94f6b0;
+  --font: "IBM Plex Mono", SFMono-Regular, Consolas, "Liberation Mono", Menlo,
+    monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  background: radial-gradient(circle at top, #101b30 0%, #020409 55%, #000 100%);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  position: relative;
+  overflow: hidden;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: absolute;
+  inset: -40%;
+  background: radial-gradient(
+      circle at 20% 30%,
+      rgba(126, 252, 246, 0.12),
+      transparent 55%
+    ),
+    radial-gradient(circle at 80% 70%, rgba(105, 153, 255, 0.1), transparent 60%),
+    radial-gradient(circle at 50% 50%, rgba(255, 0, 128, 0.08), transparent 60%);
+  filter: blur(90px);
+  z-index: -2;
+  animation: drift 22s linear infinite;
+}
+
+body::after {
+  background: radial-gradient(circle, rgba(126, 252, 246, 0.16) 0%, transparent 55%);
+  mix-blend-mode: screen;
+  animation-duration: 32s;
+  opacity: 0.6;
+}
+
+.viewport {
+  width: min(960px, 100%);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(126, 252, 246, 0.3);
+  border-radius: 18px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+  position: relative;
+  animation: float 12s ease-in-out infinite;
+}
+
+.hero {
+  background: rgba(5, 8, 14, 0.85);
+  border-bottom: 1px solid rgba(126, 252, 246, 0.2);
+  padding: 32px clamp(20px, 5vw, 48px);
+  position: relative;
+}
+
+.hero h1 {
+  margin: 0 0 12px;
+  font-weight: 600;
+  font-size: clamp(22px, 4vw, 32px);
+  color: var(--accent);
+  text-shadow: 0 0 18px rgba(126, 252, 246, 0.35);
+}
+
+.hero p {
+  margin: 0;
+  line-height: 1.6;
+  color: var(--muted);
+  animation: fadeIn 1.4s ease;
+}
+
+.command {
+  color: var(--accent);
+}
+
+.terminal {
+  background: var(--panel);
+  padding: 24px clamp(16px, 4vw, 40px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.terminal__output {
+  flex: 1;
+  min-height: 320px;
+  max-height: 540px;
+  overflow-y: auto;
+  font-size: 15px;
+  line-height: 1.7;
+  letter-spacing: 0.4px;
+  padding-right: 12px;
+}
+
+.line + .line {
+  margin-top: 8px;
+}
+
+.line {
+  animation: slideIn 0.35s ease;
+}
+
+.terminal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 6px 0 4px;
+}
+
+.chip {
+  background: rgba(14, 25, 40, 0.92);
+  border: 1px solid rgba(126, 252, 246, 0.35);
+  border-radius: 999px;
+  color: var(--accent);
+  padding: 6px 16px;
+  font-family: inherit;
+  font-size: 13px;
+  letter-spacing: 0.4px;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s;
+  position: relative;
+}
+
+.chip:hover,
+.chip:focus-visible {
+  transform: translateY(-1px) scale(1.02);
+  box-shadow: 0 8px 20px rgba(126, 252, 246, 0.2);
+  border-color: rgba(126, 252, 246, 0.6);
+  outline: none;
+}
+
+.chip:active {
+  transform: translateY(0);
+}
+
+.chip--ghost {
+  color: var(--muted);
+  border-color: rgba(148, 246, 176, 0.3);
+}
+
+.chip--ghost[data-state="on"] {
+  color: var(--accent);
+  border-color: rgba(126, 252, 246, 0.6);
+  box-shadow: 0 8px 18px rgba(126, 252, 246, 0.18);
+}
+
+.terminal__input {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 16px;
+}
+
+.prompt {
+  color: var(--prompt);
+}
+
+.terminal__input input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid rgba(148, 246, 176, 0.35);
+  padding: 6px 4px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.terminal__input input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 6px 18px rgba(126, 252, 246, 0.1);
+}
+
+.footer {
+  background: rgba(5, 8, 14, 0.85);
+  border-top: 1px solid rgba(126, 252, 246, 0.2);
+  padding: 18px clamp(20px, 5vw, 48px);
+  font-size: 13px;
+  color: var(--muted);
+  text-align: center;
+  animation: fadeIn 1.2s ease 0.3s backwards;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(126, 252, 246, 0.4);
+  border-radius: 999px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 600px) {
+  body {
+    padding: 12px;
+  }
+
+  .terminal__output {
+    min-height: 260px;
+    max-height: 400px;
+  }
+}
+
+@keyframes drift {
+  0% {
+    transform: translate3d(-2%, -2%, 0) scale(1.02);
+  }
+  50% {
+    transform: translate3d(2%, 2%, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(-2%, -2%, 0) scale(1.02);
+  }
+}
+
+@keyframes float {
+  0% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+  100% {
+    transform: translateY(0px);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}


### PR DESCRIPTION
## Summary
- add suggested command buttons with a sound toggle so visitors can jump into key commands instantly
- implement an ambient synth soundscape plus floating/neon animations to deepen the terminal vibe
- refactor the command processor so both quick actions and manual input share history and feedback

## Testing
- Not run (static web app)


------
https://chatgpt.com/codex/tasks/task_e_68e4427edf10832bbca21011f72a06f4